### PR TITLE
FIXED Notice

### DIFF
--- a/src/modules/Pages/lib/Pages/Controller/User.php
+++ b/src/modules/Pages/lib/Pages/Controller/User.php
@@ -285,6 +285,8 @@ class Pages_Controller_User extends Zikula_AbstractController
         // Display Admin Edit Link
         if (SecurityUtil::checkPermission('Pages::Page', "{$item['title']}::{$item['pageid']}", ACCESS_EDIT)) {
             $item['displayeditlink'] = true;
+        } else {
+            $item['displayeditlink'] = false;                
         }
 
         // Assign details of the item.


### PR DESCRIPTION
The templates throws a notice when you are not logged in, because of the check for "displayeditlink" which doesn't exist.
