### PR TITLE
Metatags styling in modify temlate

### DIFF
--- a/templates/admin/modify.tpl
+++ b/templates/admin/modify.tpl
@@ -50,12 +50,14 @@
         <div class="form-group">
             {formlabel cssClass="col-lg-3" for="metadescription" __text='Description'}
             <div class="col-lg-9">
-                {formtextinput id="metadescription" cssClass="form-control" maxLength="255"}
+                {formtextinput textMode="multiline" id="metadescription" rows="2" cols="50" cssClass="form-control noeditor"}
             </div>
         </div>
         <div class="form-group">
             {formlabel cssClass="col-lg-3" for="metakeywords" __text='Keywords'}
-            {formtextinput textMode="multiline" id="metakeywords" rows="4" cols="50"}
+            <div class="col-lg-9">
+                {formtextinput textMode="multiline" id="metakeywords" rows="2" cols="50" cssClass="form-control noeditor"}
+            </div>
         </div>
     </fieldset>
     <fieldset>


### PR DESCRIPTION
This PR adds class `noeditor` to metatags (metadescription and metakeywords), so if Scribite is hooked to Pages, these fields to remain simple (no visual editor for them).
This also removes maxLength="255" for metadescription, and also make both fields equal in the form (multiline) - see picture below.
![image](https://cloud.githubusercontent.com/assets/628801/3551430/07da8298-08e7-11e4-9587-cc7f1808bc86.png)
